### PR TITLE
Operar fuera de horario

### DIFF
--- a/intranet/modules/C4/AR/Mensajes.pm
+++ b/intranet/modules/C4/AR/Mensajes.pm
@@ -74,11 +74,12 @@ my %mensajesOPAC = (
     'S206' => 'Disculpe, no se puede efectuar la reserva porque tiene ejemplar/es vencido/s.',
     'U300' => 'Disculpe, no puede efectuar reservas porque comple la condici&oacute;n debido a las normas de la Biblioteca.',
     'U301' => 'Disculpe, no puede efectuar reservas porque usted no ha realizado a&uacute;n el curso para usuarios.',
-    'U302' => 'El ejemplar que acaba de reservar puede ser retirado hasta el d&iacute;a: *?*.',
+    'U302' => 'El ejemplar que acaba de reservar puede ser retirado hasta el d&iacute;a: *?* a las *?*',
     'U303' => 'En este momento no hay ejemplares disponibles para pr&eacute;stamo inmediato. 
                 Cuando haya alg&uacute;n ejemplar a su disposici&oacute;n se le informar&aacute; a 
                 <br><i> *?* </i><br>Verifique que sus datos sean correctos ya que el mensaje se enviar&aacute; a esta direcci&oacute;n.',
     'U304' => 'Disculpe, no puede reservar porque no hizo el curso para usuarios.',
+    'U305' => 'El ejemplar que acaba de reservar puede ser retirado hasta el d&iacute;a: *?*',
     'U308' => 'Se cancel&oacute; la reserva con &eacute;xito.',
     'U315' => 'Las passwords no coinciden, ingrese la password nuevamente.',
     'U338' => 'Se modificaron los datos del usuario correctamente.',

--- a/intranet/modules/C4/AR/Reservas.pm
+++ b/intranet/modules/C4/AR/Reservas.pm
@@ -1123,12 +1123,11 @@ sub t_reservarOPAC {
 
             #Se setean los parametros para el mensaje de la reserva SIN ERRORES
             if($paramsReserva->{'estado'} eq 'E'){
-	            C4::AR::Debug::debug("SE RESERVO CON EXITO UN EJEMPLAR!!! codMsg: U302");
+	            C4::AR::Debug::debug("SE RESERVO CON EXITO UN EJEMPLAR!!! codMsg: U305");
 	            #SE RESERVO CON EXITO UN EJEMPLAR
                 $msg_object->{'error'} = 0;
-                C4::AR::Mensajes::add($msg_object, {'codMsg'=> 'U302', 'tipo'=> 'opac', 'params' => [    
+                C4::AR::Mensajes::add($msg_object, {'codMsg'=> 'U305', 'tipo'=> 'opac', 'params' => [    
                                                                                         $paramsReserva->{'hasta'}
-                                                                                        
                                 ]} ) ;
 
             }else{


### PR DESCRIPTION
Se oculto el horario que se mostraba al reservar un ejemplar desde el opac
